### PR TITLE
RENW-563 Display rug sizes as options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,7 @@
 
 The Similar Products Variants app returns similar products related to an SKU so users can select other dimensions of the same product.
 
-
-![similar-in-action](https://user-images.githubusercontent.com/67270558/147780521-db76029b-c1fa-4627-a8bb-fa7485355424.png)
+![Screenshot 2023-12-18 at 17 09 23](https://github.com/syatt-io/renwil-similar-products-variants/assets/44602686/4ef83766-0856-42af-8df0-b174d4c94d11)
 
 ## Before you start
 1. Set up similar products in your store’s **Products and SKU.** Access your store’s Admin and go to **Products > Catalog > Products and SKU**.

--- a/react/Index.tsx
+++ b/react/Index.tsx
@@ -21,13 +21,12 @@ const CSS_HANDLES = [
   'variants',
   'title',
   'var-wrap',
-  'img_wrap',
-  'img',
+  'link_wrap',
+  'text',
 ] as const
 
 function SimilarProductsVariants({
   productQuery,
-  imageLabel,
 }: SimilarProductsVariantsProps) {
   const handles = useCssHandles(CSS_HANDLES)
   const intl = useIntl()
@@ -78,24 +77,20 @@ function SimilarProductsVariants({
         {intl.formatMessage({ id: 'store/title.label' })}
       </p>
       <div className={handles['var-wrap']}>
-        {items.map((element: ProductTypes.Product) => {
-          const imageIndex =
-            imageLabel === undefined
-              ? 0
-              : element.items[0].images.findIndex(
-                  image => image.imageLabel === imageLabel
-                ) === -1
-              ? 0
-              : element.items[0].images.findIndex(
-                  image => image.imageLabel === imageLabel
-                )
+        {items.map((element: ProductTypes.Product, index: number) => {
+          const dimensionSizeArray = items[index].specificationGroups.filter(
+            item => item.name === 'Dimensions'
+          )
 
-          const srcImage = element.items[0].images[imageIndex].imageUrl
+          const dimensionSizeText =
+            dimensionSizeArray.length && dimensionSizeArray[0].name
+              ? dimensionSizeArray[0].specifications[0].name
+              : `Size ${index + 1}`
 
           return (
             <Link
               key={element.productId}
-              className={`${handles.img_wrap}${
+              className={`${handles.link_wrap}${
                 route?.params?.slug === element.linkText ? '--is-active' : ''
               }`}
               {...{
@@ -106,14 +101,7 @@ function SimilarProductsVariants({
                 },
               }}
             >
-              <img
-                src={srcImage}
-                alt={element.productName}
-                height="50px"
-                className={`${handles.img} mr3 ${
-                  route?.params?.slug === element.linkText ? 'o-50' : ''
-                }`}
-              />
+              <p className={`${handles.text}`}>{dimensionSizeText}</p>
             </Link>
           )
         })}

--- a/react/Index.tsx
+++ b/react/Index.tsx
@@ -14,18 +14,20 @@ interface SimilarProductsVariantsProps {
       productId: string
     }
   }
+  imageLabel: string
 }
 
 const CSS_HANDLES = [
   'variants',
   'title',
   'var-wrap',
-  'link_wrap',
-  'text',
+  'img_wrap',
+  'img',
 ] as const
 
 function SimilarProductsVariants({
   productQuery,
+  imageLabel,
 }: SimilarProductsVariantsProps) {
   const handles = useCssHandles(CSS_HANDLES)
   const intl = useIntl()
@@ -76,20 +78,24 @@ function SimilarProductsVariants({
         {intl.formatMessage({ id: 'store/title.label' })}
       </p>
       <div className={handles['var-wrap']}>
-        {items.map((element: ProductTypes.Product, index: number) => {
-          const dimensionSizeArray = items[index].specificationGroups.filter(
-            item => item.name === 'Dimensions'
-          )
+        {items.map((element: ProductTypes.Product) => {
+          const imageIndex =
+            imageLabel === undefined
+              ? 0
+              : element.items[0].images.findIndex(
+                  image => image.imageLabel === imageLabel
+                ) === -1
+              ? 0
+              : element.items[0].images.findIndex(
+                  image => image.imageLabel === imageLabel
+                )
 
-          const dimensionSizeText =
-            dimensionSizeArray.length && dimensionSizeArray[0].name
-              ? dimensionSizeArray[0].specifications[0].name
-              : `Size ${index + 1}`
+          const srcImage = element.items[0].images[imageIndex].imageUrl
 
           return (
             <Link
               key={element.productId}
-              className={`${handles.link_wrap}${
+              className={`${handles.img_wrap}${
                 route?.params?.slug === element.linkText ? '--is-active' : ''
               }`}
               {...{
@@ -100,7 +106,14 @@ function SimilarProductsVariants({
                 },
               }}
             >
-              <p className={`${handles.text}`}>{dimensionSizeText}</p>
+              <img
+                src={srcImage}
+                alt={element.productName}
+                height="50px"
+                className={`${handles.img} mr3 ${
+                  route?.params?.slug === element.linkText ? 'o-50' : ''
+                }`}
+              />
             </Link>
           )
         })}

--- a/react/Index.tsx
+++ b/react/Index.tsx
@@ -14,20 +14,18 @@ interface SimilarProductsVariantsProps {
       productId: string
     }
   }
-  imageLabel: string
 }
 
 const CSS_HANDLES = [
   'variants',
   'title',
   'var-wrap',
-  'img_wrap',
-  'img',
+  'link_wrap',
+  'text',
 ] as const
 
 function SimilarProductsVariants({
   productQuery,
-  imageLabel,
 }: SimilarProductsVariantsProps) {
   const handles = useCssHandles(CSS_HANDLES)
   const intl = useIntl()
@@ -78,24 +76,20 @@ function SimilarProductsVariants({
         {intl.formatMessage({ id: 'store/title.label' })}
       </p>
       <div className={handles['var-wrap']}>
-        {items.map((element: ProductTypes.Product) => {
-          const imageIndex =
-            imageLabel === undefined
-              ? 0
-              : element.items[0].images.findIndex(
-                  image => image.imageLabel === imageLabel
-                ) === -1
-              ? 0
-              : element.items[0].images.findIndex(
-                  image => image.imageLabel === imageLabel
-                )
+        {items.map((element: ProductTypes.Product, index: number) => {
+          const dimensionSizeArray = items[index].specificationGroups.filter(
+            item => item.name === 'Dimensions'
+          )
 
-          const srcImage = element.items[0].images[imageIndex].imageUrl
+          const dimensionSizeText =
+            dimensionSizeArray.length && dimensionSizeArray[0].name
+              ? dimensionSizeArray[0].specifications[0].name
+              : `Size ${index + 1}`
 
           return (
             <Link
               key={element.productId}
-              className={`${handles.img_wrap}${
+              className={`${handles.link_wrap}${
                 route?.params?.slug === element.linkText ? '--is-active' : ''
               }`}
               {...{
@@ -106,14 +100,7 @@ function SimilarProductsVariants({
                 },
               }}
             >
-              <img
-                src={srcImage}
-                alt={element.productName}
-                height="50px"
-                className={`${handles.img} mr3 ${
-                  route?.params?.slug === element.linkText ? 'o-50' : ''
-                }`}
-              />
+              <p className={`${handles.text}`}>{dimensionSizeText}</p>
             </Link>
           )
         })}


### PR DESCRIPTION
## Description

The Renwil team would like to display rug size options on the PDP. They currently don’t have the data to support creating them as SKUs of a single product so we will use this app from VTEX - [GitHub - vtex-apps/similar-products-variants: The Similar Products Variants app returns similar products related to an SKU so users can select other colors or types of the same product.](https://github.com/vtex-apps/similar-products-variants) 

The catch is we need to display the dimensions specification instead of the SKU name, which means we’ll likely need to fork this app and make the required change.

## Ticket

https://syatt.atlassian.net/browse/RENW-563

## Preview

https://renw563--renwil.myvtex.com/napoli-rnap-10183/p?__bindingAddress=www.renwil.com/en
